### PR TITLE
Prepare Support to Lseek32!

### DIFF
--- a/usbhostfs/hooks_io.c
+++ b/usbhostfs/hooks_io.c
@@ -17,6 +17,7 @@ static Hook hooks[HOOK_END] = {
         {-1, 0, "SceIofilemgr", 0x40FD29C7, 0xE17EFC03, _ksceIoRead},
         {-1, 0, "SceIofilemgr", 0x40FD29C7, 0x21EE91F0, _ksceIoWrite},
         {-1, 0, "SceIofilemgr", 0x40FD29C7, 0x62090481, _ksceIoLseek},
+		{-1, 0, "SceIofilemgr", 0x40FD29C7, 0x62090481 /*No NID Know*/, _ksceIoLseek32},
         {-1, 0, "SceIofilemgr", 0x40FD29C7, 0x0D7BB3E1, _ksceIoRemove},
         {-1, 0, "SceIofilemgr", 0x40FD29C7, 0xDC0C4997, _ksceIoRename},
         // io/fcntl.h
@@ -231,6 +232,23 @@ SceOff _ksceIoLseek(SceUID uid, SceOff offset, int whence) {
 
     res = io_lseek(ffd->fd, offset, whence);
     printf("_ksceIoLseek(0x%08X, %lld, %i) == %lld\n", ffd->fd, offset, whence, res);
+
+    return res;
+}
+
+int _ksceIoLseek32(SceUID uid, int offset, int whence) {
+
+    int res;
+    fopen_fd *ffd;
+
+    res = ksceKernelGetObjForUid(uid, &p2sIoClass, (SceObjectBase **) &ffd);
+    if (res < 0) {
+        //printf("_ksceIoLseek32: ksceKernelGetObjForUid(%x): 0x%08X\n", uid, res);
+        return TAI_CONTINUE(int, hooks[HOOK_IO_KLSEEK32].ref, uid, offset, whence);
+    }
+
+    res = io_lseek(ffd->fd, offset, whence);
+    printf("_ksceIoLseek32(0x%08X, %lld, %i) == %lld\n", ffd->fd, offset, whence, res);
 
     return res;
 }

--- a/usbhostfs/hooks_io.h
+++ b/usbhostfs/hooks_io.h
@@ -38,6 +38,7 @@ enum {
     HOOK_IO_KREAD,
     HOOK_IO_KWRITE,
     HOOK_IO_KLSEEK,
+	HOOK_IO_KLSEEK32,
     HOOK_IO_KREMOVE,
     HOOK_IO_KRENAME,
     HOOK_IO_KDOPEN,
@@ -64,6 +65,8 @@ int _ksceIoRead(SceUID fd, void *data, SceSize size);
 int _ksceIoWrite(SceUID fd, const void *data, SceSize size);
 
 SceOff _ksceIoLseek(SceUID fd, SceOff offset, int whence);
+
+int _ksceIoLseek32(SceUID uid, int offset, int whence);
 
 int _ksceIoRemove(const char *file);
 


### PR DESCRIPTION
I was testing the usbhostfs, really very good,
But it failed in some functions of several Homebrews,
So try a little bit, and it turns out that it makes an error when performing Lseek32, try to add it, but I did not find the NID in vitasdk, only the normal Lseek in kernel, and both in user.